### PR TITLE
fix(SOURSD-880): Possible unbound memory growth detected, with the si…

### DIFF
--- a/app/Jobs/UpdateActionNotifications.php
+++ b/app/Jobs/UpdateActionNotifications.php
@@ -42,7 +42,7 @@ class UpdateActionNotifications implements ShouldQueue
         $this->processUsers(User::GROUP_CUSTODIANS, User::query());
     }
 
-    private function processUsers(string $group, &$query): void
+    private function processUsers(string $group, $query): void
     {
         $query->where("user_group", $group)
             ->chunk($this->chunkSize, function ($users) use ($group) {


### PR DESCRIPTION
…ze of the eloquent models and relationships being pulled. Adding this to see if it clears down allocations, as laravel doesn't automatically release memory when chunking